### PR TITLE
Add to support open Popover as a child window.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "rustc-hash",
 ]
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "anyhow",
  "futures",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "derive_refineable",
 ]
@@ -4481,7 +4481,7 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 [[package]]
 name = "semantic_version"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "anyhow",
  "serde",
@@ -4894,7 +4894,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "arrayvec",
  "log",
@@ -5553,7 +5553,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
+source = "git+https://github.com/zed-industries/zed.git#5bc3846d592dc7e9acb81f709cc7257ae594bc77"
 dependencies = [
  "anyhow",
  "async-fs 1.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,8 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
+version = "0.9.0"
+source = "git+https://github.com/bilelmoussaoui/ashpd?rev=29f2e1a#29f2e1a6f4b0911f504658f5f4630c02e01b13f2"
 dependencies = [
  "async-fs 2.1.2",
  "async-net 2.0.0",
@@ -917,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "rustc-hash",
 ]
@@ -1230,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2181,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2222,11 +2221,9 @@ dependencies = [
  "log",
  "media",
  "metal",
- "mio",
  "num_cpus",
  "objc",
  "oo7",
- "open",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -2269,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2454,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "anyhow",
  "futures",
@@ -2728,25 +2725,6 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
 ]
 
 [[package]]
@@ -3128,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -3213,19 +3191,6 @@ name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
-
-[[package]]
-name = "mio"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4929e1f84c5e54c3ec6141cd5d8b5a5c055f031f80cf78f2072920173cb4d880"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "naga"
@@ -3532,17 +3497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "open"
-version = "5.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,12 +3589,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pathfinder_geometry"
@@ -4258,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "derive_refineable",
 ]
@@ -4533,7 +4481,7 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 [[package]]
 name = "semantic_version"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "anyhow",
  "serde",
@@ -4946,7 +4894,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "arrayvec",
  "log",
@@ -5605,7 +5553,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#ed09bb949c2be7972234fe9cbb06def686182860"
+source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
 dependencies = [
  "anyhow",
  "async-fs 1.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "rustc-hash",
 ]
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "anyhow",
  "futures",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "derive_refineable",
 ]
@@ -4481,7 +4481,7 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 [[package]]
 name = "semantic_version"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "anyhow",
  "serde",
@@ -4894,7 +4894,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "arrayvec",
  "log",
@@ -5553,7 +5553,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git#9a6f30fd950d95beba36e5c547d78f2b495dd609"
+source = "git+https://github.com/zed-industries/zed.git#ba7d5a3d4cd361301ab93add9b2dac07e0a3ec58"
 dependencies = [
  "anyhow",
  "async-fs 1.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ default-members = ["crates/app"]
 resolver = "2"
 
 [workspace.dependencies]
+# gpui = { path = "/Users/jason/github/zed/crates/gpui" }
 gpui = { git = "https://github.com/zed-industries/zed.git" }
 ui = { path = "crates/ui" }
 story = { path = "crates/story" }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -12,10 +12,6 @@ mod story_workspace;
 actions!(main_menu, [Quit, Copy]);
 
 fn init(app_state: Arc<AppState>, cx: &mut AppContext) -> Result<()> {
-    if std::env::var("MTL_HUD_ENABLED").is_err() {
-        std::env::set_var("MTL_HUD_ENABLED", "1");
-    }
-
     story_workspace::init(app_state.clone(), cx);
 
     cx.bind_keys([

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -180,7 +180,7 @@ impl Render for PopoverStory {
                             .trigger(Button::new("popup-menu-1", cx).icon(IconName::Info))
                             .content(move |cx| {
                                 let focus_handle = focus_handle.clone();
-                                PopupMenu::build(cx, |mut this, _| {
+                                PopupMenu::build(cx, |mut this, cx| {
                                     this.content(focus_handle)
                                         .menu("Copy", Box::new(Copy))
                                         .menu("Cut", Box::new(Cut))

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -10,6 +10,8 @@ use ui::{
     input::TextInput,
     popover::{Popover, PopoverContent},
     popup_menu::PopupMenu,
+    prelude::FluentBuilder,
+    switch::Switch,
     v_flex, Clickable, IconName,
 };
 
@@ -54,6 +56,7 @@ pub struct PopoverStory {
     focus_handle: FocusHandle,
     form: View<Form>,
     message: String,
+    window_mode: bool,
 }
 
 impl PopoverStory {
@@ -67,6 +70,7 @@ impl PopoverStory {
             form,
             focus_handle: cx.focus_handle(),
             message: "".to_string(),
+            window_mode: false,
         }
     }
 
@@ -111,12 +115,21 @@ impl Render for PopoverStory {
             }))
             .gap_6()
             .child(
+                Switch::new("switch-window-mode")
+                    .checked(self.window_mode)
+                    .label("Use Window Popover")
+                    .on_click(cx.listener(|this, _, cx| {
+                        this.window_mode = !this.window_mode;
+                    })),
+            )
+            .child(
                 h_flex()
                     .items_center()
                     .justify_between()
                     .child(
                         v_flex().gap_4().child(
-                            Popover::new_window("info-top-left")
+                            Popover::new("info-top-left")
+                                .when(self.window_mode, |this| this.window_mode())
                                 .trigger(Button::new("info-top-left", cx).label("Top Left"))
                                 .content(|cx| {
                                     PopoverContent::new(cx, |cx| {
@@ -137,6 +150,7 @@ impl Render for PopoverStory {
                     )
                     .child(
                         Popover::new("info-top-right")
+                            .when(self.window_mode, |this| this.window_mode())
                             .anchor(AnchorCorner::TopRight)
                             .trigger(Button::new("info-top-right", cx).label("Top Right"))
                             .content(|cx| {
@@ -144,7 +158,7 @@ impl Render for PopoverStory {
                                     v_flex()
                                         .gap_4()
                                         .w_96()
-                                        .child("Hello, this is a Popover on the Top Right, this Popover is not window.")
+                                        .child("Hello, this is a Popover on the Top Right.")
                                         .child(Divider::horizontal())
                                         .child(
                                             Button::new("info1", cx)
@@ -160,7 +174,8 @@ impl Render for PopoverStory {
             .child(
                 h_flex()
                     .child(
-                        Popover::new_window("popup-menu")
+                        Popover::new("popup-menu")
+                            .when(self.window_mode, |this| this.window_mode())
                             .trigger(Button::new("popup-menu-1", cx).icon(IconName::Info))
                             .content(move |cx| {
                                 let focus_handle = focus_handle.clone();
@@ -188,7 +203,8 @@ impl Render for PopoverStory {
                         .items_center()
                         .justify_between()
                         .child(
-                            Popover::new_window("info-bottom-left")
+                            Popover::new("info-bottom-left")
+                                .when(self.window_mode, |this| this.window_mode())
                                 .anchor(AnchorCorner::BottomLeft)
                                 .trigger(
                                     Button::new("pop", cx)
@@ -198,7 +214,8 @@ impl Render for PopoverStory {
                                 .content(move |_| form.clone()),
                         )
                         .child(
-                            Popover::new_window("info-bottom-right")
+                            Popover::new("info-bottom-right")
+                                .when(self.window_mode, |this| this.window_mode())
                                 .anchor(AnchorCorner::BottomRight)
                                 .mouse_button(MouseButton::Right)
                                 .trigger(

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -74,7 +74,7 @@ impl PopoverStory {
         }
     }
 
-    fn on_copy(&mut self, _: &Copy, cx: &mut ViewContext<Self>) {
+    fn on_copy(&mut self, _: &Copy, _: &mut ViewContext<Self>) {
         self.message = "You have clicked copy".to_string();
     }
     fn on_cut(&mut self, _: &Cut, _: &mut ViewContext<Self>) {
@@ -118,7 +118,7 @@ impl Render for PopoverStory {
                 Switch::new("switch-window-mode")
                     .checked(self.window_mode)
                     .label("Use Window Popover")
-                    .on_click(cx.listener(|this, _, cx| {
+                    .on_click(cx.listener(|this, _, _| {
                         this.window_mode = !this.window_mode;
                     })),
             )
@@ -173,6 +173,7 @@ impl Render for PopoverStory {
             )
             .child(
                 h_flex()
+                    .gap_3()
                     .child(
                         Popover::new("popup-menu")
                             .when(self.window_mode, |this| this.window_mode())

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -116,7 +116,7 @@ impl Render for PopoverStory {
                     .justify_between()
                     .child(
                         v_flex().gap_4().child(
-                            Popover::new("info-top-left")
+                            Popover::new_window("info-top-left")
                                 .trigger(Button::new("info-top-left", cx).label("Top Left"))
                                 .content(|cx| {
                                     PopoverContent::new(cx, |cx| {
@@ -143,7 +143,8 @@ impl Render for PopoverStory {
                                 PopoverContent::new(cx, |cx| {
                                     v_flex()
                                         .gap_4()
-                                        .child("Hello, this is a Popover on the Top Right.")
+                                        .w_96()
+                                        .child("Hello, this is a Popover on the Top Right, this Popover is not window.")
                                         .child(Divider::horizontal())
                                         .child(
                                             Button::new("info1", cx)
@@ -159,7 +160,7 @@ impl Render for PopoverStory {
             .child(
                 h_flex()
                     .child(
-                        Popover::new("popup-menu")
+                        Popover::new_window("popup-menu")
                             .trigger(Button::new("popup-menu-1", cx).icon(IconName::Info))
                             .content(move |cx| {
                                 let focus_handle = focus_handle.clone();
@@ -187,7 +188,7 @@ impl Render for PopoverStory {
                         .items_center()
                         .justify_between()
                         .child(
-                            Popover::new("info-bottom-left")
+                            Popover::new_window("info-bottom-left")
                                 .anchor(AnchorCorner::BottomLeft)
                                 .trigger(
                                     Button::new("pop", cx)
@@ -197,7 +198,7 @@ impl Render for PopoverStory {
                                 .content(move |_| form.clone()),
                         )
                         .child(
-                            Popover::new("info-bottom-right")
+                            Popover::new_window("info-bottom-right")
                                 .anchor(AnchorCorner::BottomRight)
                                 .mouse_button(MouseButton::Right)
                                 .trigger(

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -53,6 +53,7 @@ impl Render for Form {
 pub struct PopoverStory {
     focus_handle: FocusHandle,
     form: View<Form>,
+    message: String,
 }
 
 impl PopoverStory {
@@ -65,20 +66,21 @@ impl PopoverStory {
         Self {
             form,
             focus_handle: cx.focus_handle(),
+            message: "".to_string(),
         }
     }
 
-    fn on_copy(&mut self, _: &Copy, _: &mut ViewContext<Self>) {
-        println!("You have clicked copy");
+    fn on_copy(&mut self, _: &Copy, cx: &mut ViewContext<Self>) {
+        self.message = "You have clicked copy".to_string();
     }
     fn on_cut(&mut self, _: &Cut, _: &mut ViewContext<Self>) {
-        println!("You have clicked cut");
+        self.message = "You have clicked cut".to_string();
     }
     fn on_paste(&mut self, _: &Paste, _: &mut ViewContext<Self>) {
-        println!("You have clicked paste");
+        self.message = "You have clicked paste".to_string();
     }
     fn on_search_all(&mut self, _: &SearchAll, _: &mut ViewContext<Self>) {
-        println!("You have clicked SearchAll");
+        self.message = "You have clicked search all".to_string();
     }
 }
 
@@ -155,27 +157,29 @@ impl Render for PopoverStory {
                     ),
             )
             .child(
-                h_flex().child(
-                    Popover::new("popup-menu")
-                        .trigger(Button::new("popup-menu-1", cx).icon(IconName::Info))
-                        .content(move |cx| {
-                            let focus_handle = focus_handle.clone();
-                            PopupMenu::build(cx, |mut this, _| {
-                                this.content(focus_handle)
-                                    .menu("Copy", Box::new(Copy))
-                                    .menu("Cut", Box::new(Cut))
-                                    .menu("Paste", Box::new(Paste))
-                                    .separator()
-                                    .menu_with_icon(
-                                        IconName::Search,
-                                        "Search",
-                                        Box::new(SearchAll),
-                                    );
+                h_flex()
+                    .child(
+                        Popover::new("popup-menu")
+                            .trigger(Button::new("popup-menu-1", cx).icon(IconName::Info))
+                            .content(move |cx| {
+                                let focus_handle = focus_handle.clone();
+                                PopupMenu::build(cx, |mut this, _| {
+                                    this.content(focus_handle)
+                                        .menu("Copy", Box::new(Copy))
+                                        .menu("Cut", Box::new(Cut))
+                                        .menu("Paste", Box::new(Paste))
+                                        .separator()
+                                        .menu_with_icon(
+                                            IconName::Search,
+                                            "Search",
+                                            Box::new(SearchAll),
+                                        );
 
-                                this
-                            })
-                        }),
-                ),
+                                    this
+                                })
+                            }),
+                    )
+                    .child(self.message.clone()),
             )
             .child(
                 div().absolute().bottom_4().left_0().w_full().h_10().child(

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -101,18 +101,12 @@ impl Render for PopoverStory {
             .on_action(cx.listener(Self::on_paste))
             .on_action(cx.listener(Self::on_search_all))
             .p_4()
+            .mb_5()
             .size_full()
-            .min_h(px(600.))
+            .min_h(px(400.))
             .on_any_mouse_down(cx.listener(|this, _: &MouseDownEvent, cx| {
                 cx.focus(&this.focus_handle);
             }))
-            .child(
-                Button::new("test1", cx)
-                    .label("Hello")
-                    .on_click(move |_, cx| {
-                        cx.dispatch_action(Box::new(Copy));
-                    }),
-            )
             .gap_6()
             .child(
                 h_flex()

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 doctest = false
 
 [dependencies]
-# gpui = { path = "/Users/jason/github/zed/crates/gpui" }
-gpui = { git = "https://github.com/zed-industries/zed.git" }
+gpui.workspace = true
 anyhow = "1"
 log = "0.4"
 serde = "1.0.203"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 doctest = false
 
 [dependencies]
+# gpui = { path = "/Users/jason/github/zed/crates/gpui" }
 gpui = { git = "https://github.com/zed-industries/zed.git" }
 anyhow = "1"
 log = "0.4"

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -468,30 +468,30 @@ where
             window_y + trigger_bounds.origin.y + border_bounds.origin.y,
         );
 
-        println!(
-            "------------ trigger_screen_origin_y: {} {}= {}",
-            trigger_screen_origin.y,
-            bounds.size.height,
-            trigger_screen_origin.y - bounds.size.height
-        );
+        // println!(
+        //     "------------ trigger_screen_origin_y: {} {}= {}",
+        //     trigger_screen_origin.y,
+        //     bounds.size.height,
+        //     trigger_screen_origin.y - bounds.size.height
+        // );
 
         let popover_offset = px(5.);
         let popover_origin = match anchor {
             AnchorCorner::TopLeft => point(
                 trigger_screen_origin.x,
-                trigger_screen_origin.y - bounds.size.height / 2.0 - popover_offset,
+                trigger_screen_origin.y - bounds.size.height - popover_offset,
             ),
             AnchorCorner::TopRight => point(
                 trigger_screen_origin.x,
-                trigger_screen_origin.y - bounds.size.height / 2.0 - popover_offset,
+                trigger_screen_origin.y - bounds.size.height - popover_offset,
             ),
             AnchorCorner::BottomLeft => point(
                 trigger_screen_origin.x,
-                trigger_screen_origin.y + bounds.size.height / 2.0 + popover_offset,
+                trigger_screen_origin.y + trigger_bounds.size.height + popover_offset,
             ),
             AnchorCorner::BottomRight => point(
                 trigger_screen_origin.x,
-                trigger_screen_origin.y + bounds.size.height / 2.0 + popover_offset,
+                trigger_screen_origin.y + trigger_bounds.size.height + popover_offset,
             ),
         };
 
@@ -563,7 +563,8 @@ where
             .track_focus(&self.focus_handle)
             .size_full()
             .p_2()
-            .text_color(cx.theme().foreground)
+            .bg(cx.theme().popover)
+            .text_color(cx.theme().popover_foreground)
             // Leave margin for show window shadow
             .map(|d| match self.anchor {
                 AnchorCorner::TopLeft | AnchorCorner::TopRight => d.mt_8(),

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -54,7 +54,7 @@ impl Render for PopoverContent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PopupMode {
+enum PopupMode {
     View,
     Window,
 }
@@ -84,11 +84,10 @@ where
         }
     }
 
-    /// Create a new Popover with `window` mode.
-    pub fn new_window(id: impl Into<ElementId>) -> Self {
-        let mut this = Self::new(id);
-        this.mode = PopupMode::Window;
-        this
+    /// Set Popover to use Window mode
+    pub fn window_mode(mut self) -> Self {
+        self.mode = PopupMode::Window;
+        self
     }
 
     pub fn anchor(mut self, anchor: AnchorCorner) -> Self {

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -414,14 +414,11 @@ where
         PopoverWindowState::close_window(cx);
 
         let display = cx.display();
-        let window_bounds = cx.window_bounds().get_bounds();
+        let window_bounds = cx.bounds();
 
         // cx.displays().iter().for_each(|d| {
         //     println!("display: {:?}", d.bounds());
         // });
-
-        let window_x = window_bounds.origin.x;
-        let window_y = window_bounds.origin.y;
 
         // TODO: avoid out of the screen bounds
 
@@ -447,32 +444,36 @@ where
             )
         };
 
-        let trigger_screen_origin = point(
-            window_x + trigger_bounds.origin.x + border_bounds.origin.x,
-            window_y + trigger_bounds.origin.y + border_bounds.origin.y,
-        );
-
-        let popover_offset = px(5.);
-        let popover_origin = match anchor {
-            AnchorCorner::TopLeft => point(
-                trigger_screen_origin.x,
-                trigger_screen_origin.y - bounds.size.height - popover_offset,
-            ),
-            AnchorCorner::TopRight => point(
-                trigger_screen_origin.x,
-                trigger_screen_origin.y - bounds.size.height - popover_offset,
-            ),
-            AnchorCorner::BottomLeft => point(
-                trigger_screen_origin.x,
-                trigger_screen_origin.y + trigger_bounds.size.height + popover_offset,
-            ),
-            AnchorCorner::BottomRight => point(
-                trigger_screen_origin.x,
-                trigger_screen_origin.y + trigger_bounds.size.height + popover_offset,
-            ),
+        let trigger_screen_bounds = Bounds {
+            origin: window_bounds.origin + trigger_bounds.origin + border_bounds.origin,
+            size: trigger_bounds.size,
         };
 
-        let bounds = Bounds::<Pixels> {
+        let popover_offset = px(2.);
+        let popover_origin = match anchor {
+            AnchorCorner::TopLeft => {
+                trigger_screen_bounds.lower_left() + point(px(0.), popover_offset)
+            }
+            AnchorCorner::TopRight => {
+                trigger_screen_bounds.lower_right() + point(-bounds.size.width, popover_offset)
+            }
+            AnchorCorner::BottomLeft => {
+                trigger_screen_bounds.origin
+                    - point(
+                        px(0.0),
+                        bounds.size.height + border_bounds.size.height + popover_offset,
+                    )
+            }
+            AnchorCorner::BottomRight => {
+                trigger_screen_bounds.upper_right()
+                    - point(
+                        bounds.size.width,
+                        bounds.size.height + border_bounds.size.height + popover_offset,
+                    )
+            }
+        };
+
+        let bounds = Bounds {
             origin: popover_origin,
             size: size(
                 bounds.size.width + border_bounds.size.width,

--- a/crates/ui/src/popup_menu.rs
+++ b/crates/ui/src/popup_menu.rs
@@ -6,7 +6,13 @@ use gpui::{
     SharedString, Styled as _, View, ViewContext, VisualContext as _, WindowContext,
 };
 
-use crate::{h_flex, list::ListItem, theme::ActiveTheme, v_flex, Icon};
+use crate::{
+    h_flex,
+    list::ListItem,
+    popover::{self, Popover, PopoverWindow},
+    theme::ActiveTheme,
+    v_flex, Icon,
+};
 
 actions!(menu, [Confirm, Dismiss, SelectNext, SelectPrev]);
 
@@ -136,6 +142,7 @@ impl PopupMenu {
                 match item {
                     Some(PopupMenuItem::Item { handler, .. }) => {
                         handler(content, cx);
+                        self.dismiss(&Dismiss, cx)
                     }
                     _ => {}
                 }
@@ -171,6 +178,7 @@ impl PopupMenu {
 
     fn dismiss(&mut self, _: &Dismiss, cx: &mut ViewContext<Self>) {
         cx.emit(DismissEvent);
+        popover::close_popover(cx);
     }
 }
 

--- a/crates/ui/src/popup_menu.rs
+++ b/crates/ui/src/popup_menu.rs
@@ -6,13 +6,7 @@ use gpui::{
     SharedString, Styled as _, View, ViewContext, VisualContext as _, WindowContext,
 };
 
-use crate::{
-    h_flex,
-    list::ListItem,
-    popover::{self},
-    theme::ActiveTheme,
-    v_flex, Icon,
-};
+use crate::{h_flex, list::ListItem, theme::ActiveTheme, v_flex, Icon};
 
 actions!(menu, [Confirm, Dismiss, SelectNext, SelectPrev]);
 

--- a/crates/ui/src/popup_menu.rs
+++ b/crates/ui/src/popup_menu.rs
@@ -9,7 +9,7 @@ use gpui::{
 use crate::{
     h_flex,
     list::ListItem,
-    popover::{self, Popover, PopoverWindow},
+    popover::{self},
     theme::ActiveTheme,
     v_flex, Icon,
 };
@@ -178,7 +178,6 @@ impl PopupMenu {
 
     fn dismiss(&mut self, _: &Dismiss, cx: &mut ViewContext<Self>) {
         cx.emit(DismissEvent);
-        popover::close_popover(cx);
     }
 }
 


### PR DESCRIPTION
## Goal

Change to let Popup elements open into a window, to make sure the Popup windows, panels, menus render top than the WebView.

Then we can embed wry or other webview into GPUI.


https://github.com/huacnlee/gpui-component/assets/5518/ce005456-088f-4298-bf5d-2642cf96faff


----

This is also like other software, they are also used in child window to render the menus, popups.

- https://github.com/huacnlee/gpui-component/pull/2
- https://github.com/zed-industries/zed/pull/13730

## Todos

- [x] Multiple display window position.
- [x] Windows transparent background. (No transparent, just render a correct window border)
- [x] Disable window resize on Windows. 
- [ ] Handle Menu action.
- [x] Provided `popover` or `window` two mode to uses.
