### PR TITLE
Add Small, Large size support to Input and Dropdown and let them use same height.

### DIFF
--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -1,9 +1,11 @@
+use std::rc::Rc;
+
 use gpui::{
     px, IntoElement, ParentElement, Render, Styled, View, ViewContext, VisualContext, WindowContext,
 };
 
 use ui::{
-    dropdown::{Dropdown, DropdownDelegate, DropdownItem},
+    dropdown::{Dropdown, DropdownDelegate, DropdownItem, StringDropdownDelegate},
     h_flex,
     theme::ActiveTheme,
     v_flex, Selection,
@@ -20,7 +22,7 @@ impl Country {
     }
 }
 
-impl DropdownItem for Country {
+impl DropdownItem for &Country {
     fn title(&self) -> &str {
         self.name
     }
@@ -36,6 +38,8 @@ struct FuritDelegate(Vec<String>);
 pub struct DropdownStory {
     country_dropdown: View<Dropdown<CounterDelegate>>,
     furit_dropdown: View<Dropdown<FuritDelegate>>,
+    simple_dropdown1: View<Dropdown<StringDropdownDelegate>>,
+    simple_dropdown2: View<Dropdown<StringDropdownDelegate>>,
 }
 
 impl DropdownDelegate for CounterDelegate {
@@ -43,12 +47,8 @@ impl DropdownDelegate for CounterDelegate {
         self.0.len()
     }
 
-    fn get(&self, ix: usize) -> Option<&dyn DropdownItem> {
-        if let Some(item) = self.0.get(ix) {
-            Some(item)
-        } else {
-            None
-        }
+    fn get(&self, ix: usize) -> Option<impl DropdownItem> {
+        self.0.get(ix)
     }
 }
 
@@ -57,12 +57,8 @@ impl DropdownDelegate for FuritDelegate {
         self.0.len()
     }
 
-    fn get(&self, ix: usize) -> Option<&dyn DropdownItem> {
-        if let Some(item) = self.0.get(ix) {
-            Some(item)
-        } else {
-            None
-        }
+    fn get(&self, ix: usize) -> Option<impl DropdownItem> {
+        self.0.get(ix)
     }
 }
 
@@ -82,7 +78,8 @@ impl DropdownStory {
             Country::new("Ecuador", "EC"),
         ]);
 
-        let country_dropdown = cx.new_view(|cx| Dropdown::new("dropdown-country", countries, cx));
+        let country_dropdown =
+            cx.new_view(|cx| Dropdown::new("dropdown-country", countries, Some(6), cx));
 
         let furits = FuritDelegate(
             [
@@ -98,11 +95,39 @@ impl DropdownStory {
             .map(|s| s.to_string())
             .collect(),
         );
-        let furit_dropdown = cx.new_view(|cx| Dropdown::new("dropdown-furits", furits, cx));
+        let furit_dropdown = cx.new_view(|cx| Dropdown::new("dropdown-furits", furits, None, cx));
 
-        cx.new_view(|_| Self {
+        cx.new_view(|cx| Self {
             country_dropdown,
             furit_dropdown,
+            simple_dropdown1: cx.new_view(|cx| {
+                Dropdown::string_list(
+                    "string-list1",
+                    Rc::new(vec![
+                        "QPUI".into(),
+                        "Iced".into(),
+                        "QT".into(),
+                        "Cocoa".into(),
+                    ]),
+                    Some(0),
+                    cx,
+                )
+                .size(ui::Size::Small)
+            }),
+            simple_dropdown2: cx.new_view(|cx| {
+                Dropdown::string_list(
+                    "string-list2",
+                    Rc::new(vec![
+                        "Rust".into(),
+                        "Go".into(),
+                        "C++".into(),
+                        "JavaScript".into(),
+                    ]),
+                    None,
+                    cx,
+                )
+                .size(ui::Size::Small)
+            }),
         })
     }
 
@@ -137,6 +162,14 @@ impl Render for DropdownStory {
                     .border_color(cx.theme().border)
                     .gap_4()
                     .child("This is other text."),
+            )
+            .child(
+                h_flex()
+                    .items_center()
+                    .w_128()
+                    .gap_2()
+                    .child(self.simple_dropdown1.clone())
+                    .child(self.simple_dropdown2.clone()),
             )
     }
 }

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -3,7 +3,9 @@ use gpui::{
     ParentElement as _, Render, Styled, View, ViewContext, VisualContext, WindowContext,
 };
 
-use ui::{button::Button, h_flex, input::TextInput, v_flex, Clickable, FocusableCycle, IconName};
+use ui::{
+    button::Button, h_flex, input::TextInput, v_flex, Clickable, FocusableCycle, IconName, Size,
+};
 
 use crate::section;
 
@@ -24,6 +26,8 @@ pub struct InputStory {
     prefix_input1: View<TextInput>,
     suffix_input1: View<TextInput>,
     both_input1: View<TextInput>,
+    large_input: View<TextInput>,
+    small_input: View<TextInput>,
 }
 
 impl InputStory {
@@ -71,6 +75,16 @@ impl InputStory {
                 input.set_text("This is disabled input", cx);
                 input.set_disabled(true, cx);
                 input
+            }),
+            large_input: cx.new_view(|cx| {
+                TextInput::new(cx)
+                    .size(Size::Large)
+                    .placeholder("Large input")
+            }),
+            small_input: cx.new_view(|cx| {
+                TextInput::new(cx)
+                    .size(Size::Small)
+                    .placeholder("Small input")
             }),
             prefix_input1,
             suffix_input1,
@@ -134,6 +148,11 @@ impl Render for InputStory {
                     .child(self.prefix_input1.clone())
                     .child(self.both_input1.clone())
                     .child(self.suffix_input1.clone()),
+            )
+            .child(
+                section("Input Size", cx)
+                    .child(self.large_input.clone())
+                    .child(self.small_input.clone()),
             )
             .child(
                 h_flex()

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -8,7 +8,7 @@ use crate::theme::{ActiveTheme, Colorize as _};
 use crate::{scroll::Scrollbar, v_flex};
 use crate::{Icon, IconName};
 use gpui::{
-    actions, deferred, div, px, uniform_list, AppContext, FocusHandle, FocusableView,
+    actions, div, px, uniform_list, AppContext, FocusHandle, FocusableView,
     InteractiveElement as _, IntoElement, KeyBinding, Length, ListSizingBehavior, MouseButton,
     ParentElement as _, Render, Styled as _, UniformListScrollHandle, View, ViewContext,
     VisualContext as _,
@@ -118,15 +118,12 @@ where
             return None;
         }
 
-        Some(
-            deferred(Scrollbar::uniform_scroll(
-                cx.view().clone(),
-                self.scrollbar_state.clone(),
-                self.vertical_scroll_handle.clone(),
-                self.delegate.items_count(),
-            ))
-            .with_priority(2),
-        )
+        Some(Scrollbar::uniform_scroll(
+            cx.view().clone(),
+            self.scrollbar_state.clone(),
+            self.vertical_scroll_handle.clone(),
+            self.delegate.items_count(),
+        ))
     }
 
     fn scroll_to_selected_item(&mut self, _cx: &mut ViewContext<Self>) {
@@ -242,7 +239,6 @@ where
                     .min_h(px(100.))
                     .when_some(self.max_height, |this, h| this.max_h(h))
                     .overflow_hidden()
-                    .children(self.render_scrollbar(cx))
                     .child(
                         uniform_list(view, "uniform-list", items_count, {
                             move |list, visible_range, cx| {
@@ -275,7 +271,8 @@ where
                         .with_sizing_behavior(sizing_behavior)
                         .track_scroll(vertical_scroll_handle)
                         .into_any_element(),
-                    ),
+                    )
+                    .children(self.render_scrollbar(cx)),
             )
     }
 }

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -1,5 +1,5 @@
 use crate::theme::ActiveTheme;
-use gpui::{hsla, point, px, BoxShadow, FocusHandle, Pixels, Styled, WindowContext};
+use gpui::{hsla, point, px, rems, BoxShadow, FocusHandle, Pixels, Styled, WindowContext};
 use smallvec::{smallvec, SmallVec};
 
 pub enum ElevationIndex {
@@ -147,5 +147,43 @@ pub enum Size {
 impl From<Pixels> for Size {
     fn from(size: Pixels) -> Self {
         Size::Size(size)
+    }
+}
+
+#[allow(unused)]
+pub trait Sizeful<T: Styled> {
+    fn input_size(self, size: Size) -> Self;
+    fn input_px(self, size: Size) -> Self;
+    fn input_py(self, size: Size) -> Self;
+    fn input_h(self, size: Size) -> Self;
+}
+
+impl<T: Styled> Sizeful<T> for T {
+    fn input_size(self, size: Size) -> Self {
+        self.input_px(size).input_py(size).input_h(size)
+    }
+
+    fn input_px(self, size: Size) -> Self {
+        match size {
+            Size::Large => self.px_5(),
+            Size::Medium => self.px_3(),
+            _ => self.px_2(),
+        }
+    }
+
+    fn input_py(self, size: Size) -> Self {
+        match size {
+            Size::Large => self.py_5(),
+            Size::Medium => self.py_2(),
+            _ => self.py_1(),
+        }
+    }
+
+    fn input_h(self, size: Size) -> Self {
+        match size {
+            Size::Large => self.h_11().text_size(rems(1.)),
+            Size::Medium => self.h_8().text_size(rems(0.85)),
+            _ => self.h(px(26.)).text_size(rems(0.8)),
+        }
     }
 }


### PR DESCRIPTION
- Add `Dropdown::string_list` to use `Vec<SharedString>` to create dropdown for easy use.
- Add `input_px`, `input_py`, `input_h` trait methods to `Styled` element.