### PR TITLE
Add overflow scroll support to Input.

### DIFF
--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -38,7 +38,10 @@ impl InputStory {
     fn new(cx: &mut WindowContext) -> Self {
         let input1 = cx.new_view(|cx| {
             let mut input = TextInput::new(cx).cleanable(true);
-            input.set_text("Hello 世界", cx);
+            input.set_text(
+                "Hello 世界，this is GPUI component, this is a long text.",
+                cx,
+            );
             input
         });
 

--- a/crates/ui/src/input.rs
+++ b/crates/ui/src/input.rs
@@ -11,16 +11,15 @@ use crate::theme::ActiveTheme;
 use crate::{event::InterativeElementExt as _, Size};
 use crate::{Clickable, IconName, StyledExt as _};
 use blink_cursor::BlinkCursor;
+use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    actions, div, fill, point, prelude, px, relative, rems, size, AnyView, AppContext, Bounds,
-    ClickEvent, ClipboardItem, Context as _, Element, ElementId, ElementInputHandler, EventEmitter,
+    actions, div, fill, point, px, relative, rems, size, AnyView, AppContext, Bounds, ClickEvent,
+    ClipboardItem, Context as _, Element, ElementId, ElementInputHandler, EventEmitter,
     FocusHandle, FocusableView, GlobalElementId, InteractiveElement as _, IntoElement, KeyBinding,
     KeyDownEvent, LayoutId, Model, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    PaintQuad, ParentElement as _, Pixels, Point, Render, ScrollHandle, ShapedLine, SharedString,
-    StatefulInteractiveElement as _, Style, Styled as _, TextRun, UnderlineStyle, View,
-    ViewContext, ViewInputHandler, WindowContext,
+    PaintQuad, ParentElement as _, Pixels, Point, Render, ShapedLine, SharedString, Style,
+    Styled as _, TextRun, UnderlineStyle, View, ViewContext, ViewInputHandler, WindowContext,
 };
-use prelude::FluentBuilder as _;
 use unicode_segmentation::*;
 
 mod blink_cursor;
@@ -348,6 +347,7 @@ impl TextInput {
 
     fn move_to(&mut self, offset: usize, cx: &mut ViewContext<Self>) {
         self.selected_range = offset..offset;
+        self.pause_blink_cursor(cx);
         cx.notify()
     }
 
@@ -705,17 +705,11 @@ impl Element for TextElement {
             if scroll_offset.x + cursor_start < px(0.) {
                 // selection start is out of left
                 scroll_offset.x = -cursor_start;
-            } else if scroll_offset.x + cursor_end > bounds.size.width - right_margin {
-                // selection end is out of right
-                scroll_offset.x = bounds.size.width - right_margin - cursor_end;
             }
         } else {
             if scroll_offset.x + cursor_end <= px(0.) {
                 // selection end is out of left
                 scroll_offset.x = -cursor_end;
-            } else if scroll_offset.x + cursor_start > bounds.size.width - right_margin {
-                // selection start is out of right
-                scroll_offset.x = bounds.size.width - right_margin - cursor_start;
             }
         }
 

--- a/crates/ui/src/input.rs
+++ b/crates/ui/src/input.rs
@@ -38,6 +38,8 @@ actions!(
         SelectAll,
         Home,
         End,
+        SelectToHome,
+        SelectToEnd,
         ShowCharacterPalette,
         Copy,
         Cut,
@@ -64,6 +66,8 @@ pub fn init(cx: &mut AppContext) {
         KeyBinding::new("shift-right", SelectRight, None),
         KeyBinding::new("home", Home, None),
         KeyBinding::new("end", End, None),
+        KeyBinding::new("shift-home", SelectToHome, None),
+        KeyBinding::new("shift-end", SelectToEnd, None),
         #[cfg(target_os = "macos")]
         KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, None),
         #[cfg(target_os = "macos")]
@@ -258,6 +262,14 @@ impl TextInput {
     fn end(&mut self, _: &End, cx: &mut ViewContext<Self>) {
         self.pause_blink_cursor(cx);
         self.move_to(self.text.len(), cx);
+    }
+
+    fn select_to_home(&mut self, _: &SelectToHome, cx: &mut ViewContext<Self>) {
+        self.select_to(0, cx);
+    }
+
+    fn select_to_end(&mut self, _: &SelectToEnd, cx: &mut ViewContext<Self>) {
+        self.select_to(self.text.len(), cx);
     }
 
     fn backspace(&mut self, _: &Backspace, cx: &mut ViewContext<Self>) {
@@ -804,6 +816,8 @@ impl Render for TextInput {
             .on_action(cx.listener(Self::select_left))
             .on_action(cx.listener(Self::select_right))
             .on_action(cx.listener(Self::select_all))
+            .on_action(cx.listener(Self::select_to_home))
+            .on_action(cx.listener(Self::select_to_end))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))
             .on_action(cx.listener(Self::show_character_palette))


### PR DESCRIPTION
Continue #27

- Fix cut and paste invalid replace range.
- Add `Shift-Home`, `Shift-End` for select to home or end.

## Show case

https://github.com/user-attachments/assets/d99c56e3-5241-46e2-b3ac-f72ef962b0b5

