### PR TITLE
Update WebView to pass wry::WebView instance

### DIFF
--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -23,7 +23,7 @@ impl WebViewStory {
         let focus_handle = cx.focus_handle();
 
         let webview = cx.new_view(|cx| {
-            let webview = wry::WebViewBuilder::new_as_child(&cx.raw_window_handle())
+            let webview = ui::wry::WebViewBuilder::new_as_child(&cx.raw_window_handle())
                 .build()
                 .unwrap();
             WebView::new(cx, webview)

--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -22,7 +22,12 @@ impl WebViewStory {
     pub fn view(cx: &mut WindowContext) -> View<Self> {
         let focus_handle = cx.focus_handle();
 
-        let webview = cx.new_view(|cx| WebView::new(cx));
+        let webview = cx.new_view(|cx| {
+            let webview = wry::WebViewBuilder::new_as_child(&cx.raw_window_handle())
+                .build()
+                .unwrap();
+            WebView::new(cx, webview)
+        });
 
         let address_input = cx.new_view(|cx| {
             let mut input = TextInput::new(cx);

--- a/crates/ui/src/input/blink_cursor.rs
+++ b/crates/ui/src/input/blink_cursor.rs
@@ -5,7 +5,7 @@ use gpui::{ModelContext, Timer};
 /// To manage the Input cursor blinking.
 ///
 /// It will start blinking with a interval of 500ms.
-/// Every loop will notify the view to update the `visable`, and Input will observe this update to touch repaint.
+/// Every loop will notify the view to update the `visible`, and Input will observe this update to touch repaint.
 ///
 /// The input painter will check if this in visible state, then it will draw the cursor.
 pub struct BlinkCursor {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -33,6 +33,9 @@ pub mod theme;
 pub mod tooltip;
 pub mod webview;
 
+// re-export
+pub use wry;
+
 pub use clickable::Clickable;
 pub use disableable::Disableable;
 pub use event::InterativeElementExt;

--- a/crates/ui/src/webview.rs
+++ b/crates/ui/src/webview.rs
@@ -17,7 +17,7 @@ pub fn init(_cx: &AppContext) {}
 pub struct WebView {
     focus_handle: FocusHandle,
     webview: Rc<wry::WebView>,
-    visable: bool,
+    visible: bool,
 }
 
 impl WebView {
@@ -26,7 +26,7 @@ impl WebView {
 
         Self {
             focus_handle: cx.focus_handle(),
-            visable: true,
+            visible: true,
             webview: Rc::new(webview),
         }
     }
@@ -40,7 +40,7 @@ impl WebView {
     }
 
     pub fn visible(&self) -> bool {
-        self.visable
+        self.visible
     }
 
     /// Go back in the webview history.

--- a/crates/ui/src/webview.rs
+++ b/crates/ui/src/webview.rs
@@ -21,16 +21,11 @@ pub struct WebView {
 }
 
 impl WebView {
-    pub fn new(cx: &mut WindowContext) -> Self {
-        let focus_handle = cx.focus_handle();
-        let window_handle = cx.raw_window_handle();
-
-        let webview = wry::WebView::new_as_child(&window_handle)
-            .expect("failed to create webview to child window");
+    pub fn new(cx: &mut WindowContext, webview: wry::WebView) -> Self {
         let _ = webview.set_bounds(Rect::default());
 
         Self {
-            focus_handle,
+            focus_handle: cx.focus_handle(),
             visable: true,
             webview: Rc::new(webview),
         }


### PR DESCRIPTION
It's much prefer to use `WebViewBuilder` instead of [WebView::new](https://docs.rs/wry/latest/wry/struct.WebView.html#method.new)