### PR TITLE
Update demo application to activate on startup

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
                 ],
             },
         ]);
+        cx.activate(true);
 
         story_workspace::open_new(app_state.clone(), cx, |_workspace, _cx| {
             // do something


### PR DESCRIPTION

When I start up *gpui-component* its nice to be able to see that application show up,
similar to the way zed editor works upon startup...
