### PR TITLE
Fix label text align not work

### DIFF
--- a/crates/ui/src/label.rs
+++ b/crates/ui/src/label.rs
@@ -3,7 +3,7 @@ use gpui::{
     Styled, WindowContext,
 };
 
-use crate::theme::ActiveTheme;
+use crate::{h_flex, theme::ActiveTheme};
 
 #[derive(Default)]
 pub enum TextAlign {
@@ -25,7 +25,7 @@ pub struct Label {
 impl Label {
     pub fn new(label: impl Into<SharedString>) -> Self {
         Self {
-            base: div().line_height(rems(1.25)),
+            base: h_flex().line_height(rems(1.25)),
             label: label.into(),
             multiple_lines: true,
             align: TextAlign::default(),


### PR DESCRIPTION
<img width="1668" alt="image" src="https://github.com/user-attachments/assets/e1bbad88-40c3-4701-bfd0-38381e2ed67b">
