### PR TITLE
Set cursor width to an integer to prevent width fluctuation on low PPI devices.

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -931,7 +931,7 @@ impl Element for TextElement {
                 Some(fill(
                     Bounds::new(
                         point(bounds.left() + cursor_pos, bounds.top() + inset),
-                        size(px(1.5), bounds.bottom() - bounds.top() - inset * 2),
+                        size(px(2.), bounds.bottom() - bounds.top() - inset * 2),
                     ),
                     crate::blue_500(),
                 )),


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/38ceac8e-c98d-43c7-844b-0a2fb7d416a5

After

https://github.com/user-attachments/assets/e3f9c70e-773e-4606-ad6a-021b0e7fd7c9


