### PR TITLE
Correcting shacn to shadcn to uniformly use shadcn ui names

### DIFF
--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -1,4 +1,4 @@
-use gpui::{actions, div, px, AppContext, Entity, FocusHandle, InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Render, SharedString, Styled, View, ViewContext, VisualContext, WindowContext};
+use gpui::{actions, div, px, AppContext, FocusHandle, InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Render, SharedString, Styled, View, ViewContext, VisualContext, WindowContext};
 
 use crate::section;
 use ui::{

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -1,19 +1,19 @@
-use gpui::{
-    actions, div, px, AppContext, FocusHandle, InteractiveElement, IntoElement, KeyBinding,
-    ParentElement as _, Render, SharedString, Styled, View, ViewContext, VisualContext,
-    WindowContext,
-};
+use gpui::{actions, div, px, AppContext, Entity, FocusHandle, InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Render, SharedString, Styled, View, ViewContext, VisualContext, WindowContext};
 
+use crate::section;
 use ui::{
     button::Button,
     checkbox::Checkbox,
     h_flex,
     input::{InputEvent, OtpInput, TextInput},
     prelude::FluentBuilder as _,
-    v_flex, FocusableCycle, IconName, Sizable,
+    scroll::ScrollbarAxis,
+    v_flex,
+    FocusableCycle,
+    IconName,
+    Sizable,
+    StyledExt,
 };
-
-use crate::section;
 
 actions!(input_story, [Tab, TabPrev]);
 
@@ -207,6 +207,8 @@ impl Render for InputStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
             .key_context(CONTEXT)
+            .id("input-story")
+            .scrollable(cx.entity_id(), ScrollbarAxis::Vertical)
             .on_action(cx.listener(Self::tab))
             .on_action(cx.listener(Self::tab_prev))
             .size_full()

--- a/crates/ui/src/colors.rs
+++ b/crates/ui/src/colors.rs
@@ -55,18 +55,18 @@ impl ColorExt for Hsla {
     }
 }
 
-pub(crate) static DEFAULT_COLOR: once_cell::sync::Lazy<ShacnColors> =
+pub(crate) static DEFAULT_COLOR: once_cell::sync::Lazy<ShadcnColors> =
     once_cell::sync::Lazy::new(|| {
         serde_json::from_str(include_str!("../default-colors.json"))
             .expect("failed to parse default-json")
     });
 
-type ColorScales = HashMap<usize, ShacnColor>;
+type ColorScales = HashMap<usize, ShadcnColor>;
 
 mod color_scales {
     use std::collections::HashMap;
 
-    use super::{ColorScales, ShacnColor};
+    use super::{ColorScales, ShadcnColor};
 
     use serde::de::{Deserialize, Deserializer};
 
@@ -75,7 +75,7 @@ mod color_scales {
         D: Deserializer<'de>,
     {
         let mut map = HashMap::new();
-        for color in Vec::<ShacnColor>::deserialize(deserializer)? {
+        for color in Vec::<ShadcnColor>::deserialize(deserializer)? {
             map.insert(color.scale, color);
         }
         Ok(map)
@@ -83,9 +83,9 @@ mod color_scales {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-pub(crate) struct ShacnColors {
-    pub(crate) black: ShacnColor,
-    pub(crate) white: ShacnColor,
+pub(crate) struct ShadcnColors {
+    pub(crate) black: ShadcnColor,
+    pub(crate) white: ShadcnColor,
     #[serde(with = "color_scales")]
     pub(crate) slate: ColorScales,
     #[serde(with = "color_scales")]
@@ -133,7 +133,7 @@ pub(crate) struct ShacnColors {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
-pub(crate) struct ShacnColor {
+pub(crate) struct ShadcnColor {
     #[serde(default)]
     pub(crate) scale: usize,
     #[serde(deserialize_with = "from_hsa_channel", alias = "hslChannel")]


### PR DESCRIPTION
* Fixed some color naming with shadcn style
* Input story support scroll y 