### PR TITLE
dock: Fix panel zoom sometimes is not work. #197

### DIFF
--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -24,9 +24,7 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
 
 pub trait PanelView: 'static + Send + Sync {
     /// The title of the panel, default is `None`.
-    fn title(&self, _cx: &WindowContext) -> SharedString {
-        t!("Dock.Unnamed").into()
-    }
+    fn title(&self, _cx: &WindowContext) -> SharedString;
 
     fn closeable(&self, cx: &WindowContext) -> bool;
 

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -20,6 +20,7 @@ use crate::{
 
 use super::{ClosePanel, DockArea, Panel, PanelView, StackPanel, ToggleZoom};
 
+#[derive(Debug)]
 pub enum PanelEvent {
     ZoomIn,
     ZoomOut,
@@ -449,7 +450,7 @@ impl TabPanel {
         let parent_axis = stack_panel.read(cx).axis;
         let ix = stack_panel
             .read(cx)
-            .index_of_panel(cx.view().clone())
+            .index_of_panel(&cx.view())
             .unwrap_or_default();
 
         if parent_axis.is_vertical() && placement.is_vertical() {
@@ -523,6 +524,12 @@ impl TabPanel {
 }
 
 impl Panel for TabPanel {
+    fn title(&self, cx: &WindowContext) -> gpui::SharedString {
+        self.active_panel()
+            .map(|panel| panel.title(cx))
+            .unwrap_or("Empty Tab".into())
+    }
+
     fn closeable(&self, cx: &WindowContext) -> bool {
         self.active_panel()
             .map(|panel| panel.closeable(cx))


### PR DESCRIPTION
This is because the `PanelEvent::ZoomIn` is called 2 times when we click the menu (I don't why, not found the source).

So just split Zoom in, Zoom out as two difference methods to avoid this.