### PR TITLE
Use small size for calendar month item to fixed content overflow

### DIFF
--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -124,6 +124,9 @@ impl RenderOnce for Checkbox {
                     this
                 }
             })
+            .when(self.disabled, |this| {
+                this.cursor_not_allowed().text_color(cx.theme().muted_foreground)
+            })
             .when_some(
                 self.on_click.filter(|_| !self.disabled),
                 |this, on_click| {

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -593,7 +593,7 @@ impl Calendar {
                         let active = (ix + 1) as u8 == self.current_month;
 
                         self.item_button(ix, month.to_string(), active, false, false, cx)
-                            .w(relative(0.3))
+                            .w(relative(0.3)).text_sm()
                             .on_click(cx.listener(move |view, _, cx| {
                                 view.current_month = (ix + 1) as u8;
                                 view.set_view_mode(ViewMode::Day, cx);


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/6b35758d-3166-482f-8318-eb9588860659)

after:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/99cc4951-cd77-4f9a-8c62-63b25e66f0ca">

