### PR TITLE
scrollbar: Keep the original thumb position when mouse down to dragging

### DIFF
--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -522,19 +522,25 @@ impl Element for Scrollbar {
                                 // We need to keep the thumb bar still at the origin down position
                                 let drag_pos = state.get().drag_pos;
 
-                                let percentage = if is_vertical {
+                                let percentage = (if is_vertical {
                                     (event.position.y - drag_pos.y - bounds.origin.y)
                                         / (bounds.size.height - thumb_length)
                                 } else {
                                     (event.position.x - drag_pos.x - bounds.origin.x)
-                                        / (bounds.size.width - thumb_length)
-                                }
-                                .min(1.);
+                                        / (bounds.size.width - thumb_length - margin_end)
+                                })
+                                .clamp(0., 1.);
 
                                 let offset = if is_vertical {
-                                    point(scroll_handle.offset().x, -scroll_area_size * percentage)
+                                    point(
+                                        scroll_handle.offset().x,
+                                        -(scroll_area_size - container_size) * percentage,
+                                    )
                                 } else {
-                                    point(-scroll_area_size * percentage, scroll_handle.offset().y)
+                                    point(
+                                        -(scroll_area_size - container_size) * percentage,
+                                        scroll_handle.offset().y,
+                                    )
                                 };
 
                                 scroll_handle.set_offset(offset);


### PR DESCRIPTION
![2024-09-10 23 18 50](https://github.com/user-attachments/assets/58c480a3-9c92-4c7c-8e7a-b37c2ffc3526)

fix #224

1. 纵坐标的百分比是正确的，但计算 offset 时要减掉可显示区域的长度 container_size
2. 横坐标的百分比不完全正确，计算的时候需要减掉 margin_end
3. 横坐标的百分比计算 offset 时也要减掉可显示区域的长度 container_size

