### PR TITLE
button: Use primary or danger color for the disable background.

### DIFF
--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -592,6 +592,8 @@ impl ButtonStyle {
     fn disabled(&self, cx: &WindowContext) -> ButtonStyles {
         let bg = match self {
             ButtonStyle::Link | ButtonStyle::Ghost | ButtonStyle::Text => cx.theme().transparent,
+            ButtonStyle::Primary => cx.theme().primary.opacity(0.15),
+            ButtonStyle::Danger => cx.theme().destructive.opacity(0.15),
             _ => cx.theme().secondary.darken(0.2).grayscale(),
         };
         let fg = match self {


### PR DESCRIPTION
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/61162ba5-9188-4cad-a154-2584abd0fd31">

Fix #251 