### PR TITLE
dock: Keep invalid panel state info avoid missing the state.

### DIFF
--- a/crates/ui/src/dock/invalid_panel.rs
+++ b/crates/ui/src/dock/invalid_panel.rs
@@ -5,24 +5,32 @@ use gpui::{
 
 use crate::theme::ActiveTheme as _;
 
-use super::{Panel, PanelEvent};
+use super::{DockItemInfo, DockItemState, Panel, PanelEvent};
 
 pub(crate) struct InvalidPanel {
     name: SharedString,
     focus_handle: FocusHandle,
+    info: DockItemInfo,
 }
 
 impl InvalidPanel {
-    pub(crate) fn new(name: &str, cx: &mut WindowContext) -> Self {
+    pub(crate) fn new(name: &str, info: DockItemInfo, cx: &mut WindowContext) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
             name: SharedString::from(name.to_owned()),
+            info,
         }
     }
 }
 impl Panel for InvalidPanel {
     fn panel_name(&self) -> &'static str {
         "InvalidPanel"
+    }
+
+    fn dump(&self, _cx: &AppContext) -> super::DockItemState {
+        let mut state = DockItemState::new(&self.name);
+        state.info = self.info.clone();
+        state
     }
 }
 impl EventEmitter<PanelEvent> for InvalidPanel {}

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -205,8 +205,6 @@ impl DockItemState {
     }
 
     pub fn to_item(&self, dock_area: WeakView<DockArea>, cx: &mut WindowContext) -> DockItem {
-        // TODO: Use the empty panel if the panel is not registered, for the compatibility.
-
         let info = self.info.clone();
 
         let items: Vec<DockItem> = self
@@ -252,7 +250,9 @@ impl DockItemState {
                     f(dock_area.clone(), info.clone(), cx)
                 } else {
                     // Show an invalid panel if the panel is not registered.
-                    Box::new(cx.new_view(|cx| InvalidPanel::new(&self.panel_name, cx)))
+                    Box::new(
+                        cx.new_view(|cx| InvalidPanel::new(&self.panel_name, info.clone(), cx)),
+                    )
                 };
 
                 DockItem::tabs(vec![view.into()], None, &dock_area, cx)


### PR DESCRIPTION
Fix #257 