### PR TITLE
dropdown: Use difference chevron icon color for enabled/disabled dropdown.

### DIFF
--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -659,7 +659,10 @@ where
 
                                 this.child(
                                     Icon::new(icon)
-                                        .text_color(cx.theme().muted_foreground)
+                                        .text_color(match self.disabled {
+                                            true => cx.theme().muted_foreground,
+                                            false => cx.theme().accent_foreground,
+                                        })
                                         .when(self.disabled, |this| this.cursor_not_allowed()),
                                 )
                             }),


### PR DESCRIPTION
<img width="547" alt="image" src="https://github.com/user-attachments/assets/07239a63-b1ae-4462-b8ba-d30d7e7e66f5">
